### PR TITLE
Adjust team card responsiveness

### DIFF
--- a/src/components/modules/teams/ListTeams.js
+++ b/src/components/modules/teams/ListTeams.js
@@ -33,7 +33,7 @@ const ListTeams = () => {
   }, [teams]);
 
   return (
-    <div className="mb-20 space-y-6 xl:max-w-3xl 2xl:xl:max-w-full">
+    <div className="mb-20 space-y-6">
       {!data && (
         <div className="grid grid-cols-1 gap-6 lg:grid-cols-4">
           {[...Array(16)].map((elementInArray, index) => (


### PR DESCRIPTION
Team cards now take up the full width of the screen at 1440p.  I also checked mobile, tablet and 4k and as far as I can tell they are unaffected by this change.


## Before
<img width="1440" alt="before" src="https://github.com/thefullstackgroup/webapp/assets/107075637/b474a00c-6f8b-4c86-bce1-a7862a2ee8ac">

## After
<img width="1440" alt="after" src="https://github.com/thefullstackgroup/webapp/assets/107075637/2c3cfc97-6c66-4101-aba0-2028afd24724">

