### PR TITLE
fix: add changes to make dropdown menu match dark theme

### DIFF
--- a/src/components/common/elements/CountrySelect.js
+++ b/src/components/common/elements/CountrySelect.js
@@ -5,7 +5,7 @@ const CountrySelect = ({ countryName, setCountryName }) => {
     <CountryDropdown
       value={countryName}
       onChange={(val) => setCountryName(val)}
-      className="text-input"
+      className="text-input dark:bg-black"
     />
   );
 };

--- a/src/components/modules/signup/StepFive.js
+++ b/src/components/modules/signup/StepFive.js
@@ -136,7 +136,7 @@ const StepFive = ({ user, referralCode }) => {
                     Lastly, where did you hear about thefullstack?
                   </label>
                   <select
-                    className="text-input"
+                    className="text-input dark:bg-black"
                     onChange={(e) => setHearAbout(e.target.value)}
                     value={hearAbout}
                   >

--- a/src/components/modules/signup/StepOne.js
+++ b/src/components/modules/signup/StepOne.js
@@ -166,7 +166,7 @@ const StepOne = ({ user, referralCode }) => {
             <label className="label">What do you do?</label>
 
             <select
-              className="text-input"
+              className="text-input dark:bg-black"
               onChange={(e) => setCurrentTitle(e.target.value)}
               value={currentTitle || user.currentTitle || ''}
             >
@@ -177,7 +177,7 @@ const StepOne = ({ user, referralCode }) => {
                 </option>
               ))}
             </select>
-            <span className="text-base-500 mt-1 text-xs">
+            <span className="mt-1 text-xs text-base-500">
               You can always change this later
             </span>
           </div>


### PR DESCRIPTION
### PR Description

This PR addresses the issue [#17](https://github.com/thefullstackgroup/thefullstack/issues/17)

### Changes Made

In this PR, the following changes have been made to resolve the issue:

- Added TailwindCSS changes to match the dropdown menu theme in dark mode
- Changes are made in step one and step five of the signup functionality where dropdown menus are available

### Screenshots/GIFs (if applicable)
Demo of dropdown menu after changes:

Light mode:
![Step-One-Light](https://github.com/thefullstackgroup/webapp/assets/47483669/062affe5-c718-452f-b0e9-cb6a559aa428)

Dark mode:
![Step-One-Dark](https://github.com/thefullstackgroup/webapp/assets/47483669/9c2619e0-8602-45ae-ab07-17eb8a59f286)
