### PR TITLE
Fix : Delete Spark Modal Missing Styles 

### DIFF
--- a/src/components/modules/post/Detail.js
+++ b/src/components/modules/post/Detail.js
@@ -157,12 +157,12 @@ const Detail = ({ postId, user, setShowPost }) => {
       )}
 
       <ModalAlert show={isDeletePromptOpen} setShow={setIsDeletePromptOpen}>
-        <div>
+        <div className="py-8">
           <div className="justify-center sm:flex sm:items-start">
             <div className="mt-3 text-center sm:mt-0">
-              <h3 className="text-xl font-bold text-base-200">Delete post?</h3>
-              <div className="mt-2">
-                <p className="text-sm text-base-300">
+              <h3 className="text-xl font-bold">Delete post?</h3>
+              <div className="mt-2 max-w-xs">
+                <p className="text-sm">
                   Are you sure you want to delete this post?
                 </p>
               </div>
@@ -171,14 +171,14 @@ const Detail = ({ postId, user, setShowPost }) => {
           <div className="mt-5 flex justify-center space-x-2 sm:mt-4">
             <button
               type="button"
-              className="btn-primary bg-red-600/80 hover:bg-red-500"
+              className="btn btn-primary"
               onClick={() => deletePost()}
             >
               Delete
             </button>
             <button
               type="button"
-              className="btn-secondary"
+              className="btn btn-secondary"
               onClick={() => setIsDeletePromptOpen(false)}
             >
               Cancel


### PR DESCRIPTION
Fix related to the issue : https://github.com/thefullstackgroup/thefullstack/issues/20

This PR will fix the missing styles issue on the delete spark modal.

Before Fix:
<img width="624" alt="Screenshot 2023-09-30 at 18 12 46" src="https://github.com/thefullstackgroup/webapp/assets/56975162/c4af7aa0-3d8b-46bb-a87a-e75654718dba">
<img width="561" alt="Screenshot 2023-09-30 at 18 12 32" src="https://github.com/thefullstackgroup/webapp/assets/56975162/5584e98d-07b1-4ad2-9a35-34bf5755f55c">

After Fix : 
<img width="611" alt="Screenshot 2023-09-30 at 18 13 17" src="https://github.com/thefullstackgroup/webapp/assets/56975162/d31d1faf-4fec-4481-891c-ab713d02114b">
<img width="601" alt="Screenshot 2023-09-30 at 18 13 02" src="https://github.com/thefullstackgroup/webapp/assets/56975162/199b5ffc-0038-4ff9-83a6-b5ef27a6d22f">
