### PR TITLE
Fix: Connection Confirmation Modal Styles

### DIFF
--- a/src/components/common/buttons/Connect.js
+++ b/src/components/common/buttons/Connect.js
@@ -124,10 +124,10 @@ const ButtonConnect = ({
               />
             </div>
             <div className="mt-6 mb-6 flex max-w-7xl flex-col items-center sm:px-12">
-              <span className="space-x-2 text-center text-xl font-bold tracking-tight text-gray-100 sm:text-3xl">
+              <span className="space-x-2 text-center text-xl font-bold tracking-tight sm:text-3xl">
                 Boom!
               </span>
-              <span className="mt-2 space-x-2 text-center text-base font-light tracking-tight text-gray-300 sm:text-xl">
+              <span className="mt-2 space-x-2 text-center text-base font-light tracking-tight sm:text-xl">
                 Your request was sent to {connectTo.name}.
               </span>
               <span className="my-4 text-center">


### PR DESCRIPTION
I notice that when you send someone a connection, you are greeted with a modal which has grey text. This looks good on dark mode, but not on light. I removed this style so it just uses the theme like other areas

Before Fix 
<img width="567" alt="Screenshot 2023-10-16 at 20 09 52" src="https://github.com/thefullstackgroup/webapp/assets/56975162/15814069-ddd3-42ac-94ca-6dfd50f2adb7">

After Fix
<img width="552" alt="Screenshot 2023-10-16 at 20 11 48" src="https://github.com/thefullstackgroup/webapp/assets/56975162/1ecc1634-819c-457a-bea6-70db9e3a14cb">
